### PR TITLE
Marking class methods for c++ backend as virtual

### DIFF
--- a/autocoder/cpp_backend/cpptemplates.py
+++ b/autocoder/cpp_backend/cpptemplates.py
@@ -174,7 +174,7 @@ class $(smname) {
     
     // state machine implementation functions
     #for $function in $implFunctions
-    $function;
+    virtual $function;
     #end for
 
 };


### PR DESCRIPTION
It would be nice to have the backend c++ option generate virtual methods in the class. That way an implementation can inherit and override the defaults.

This change simply adds that keyword to the cpp backend template. 

I was able to run this with the state machine that I am currently working on and it produced the correct output. However is there a test setup you have in this repo that I should be running for this change?